### PR TITLE
fix(router): Ruby 3.3 compatibility issue with anonymous block parameter

### DIFF
--- a/lib/request_migrations/router.rb
+++ b/lib/request_migrations/router.rb
@@ -35,9 +35,9 @@ module RequestMigrations
       #       resources :some_new_resource
       #     end
       #   end
-      def version_constraint(constraint, &)
+      def version_constraint(constraint, &block)
         constraints VersionConstraint.new(constraint:) do
-          instance_eval(&)
+          instance_eval(&block)
         end
       end
     end


### PR DESCRIPTION
The anonymous block parameter syntax (&) causes an error in Ruby 3.3 when the parameter is used within the method body. This change uses a named parameter instead while maintaining compatibility with older Ruby versions.